### PR TITLE
Remove unformatted link to Intro Video since there is already a working, formatted link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,6 @@ Through these resources you will learn about the languages that Ada teaches and 
 ## Introduction to Programming in Python
 These lessons will introduce you to the fundamentals of programming including writing your first program, learning programming vocabulary, and learning to store and interact with data.
 
-{% include panoptoPlayer.html id="6f137996-88f0-490a-9e94-acb10170c7dd" %}
 [Intro Video](https://adaacademy.hosted.panopto.com/Panopto/Pages/Viewer.aspx?id=6f137996-88f0-490a-9e94-acb10170c7dd)
 
 | Order | Lesson                                                                                               |


### PR DESCRIPTION
An extra link looks funny in README so I'm deleting it but the actual link itself is still available and the intro video can be accessed from it.

Not sure if it was mistakenly added but if it was added intentionally then I can close this PR. Thanks!

